### PR TITLE
Tidy config file handling and remove config_file_handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,7 +2007,6 @@ dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mock_routing/src/lib.rs
+++ b/mock_routing/src/lib.rs
@@ -1576,7 +1576,7 @@ pub mod messaging {
             }
         }
 
-        fn cause(&self) -> Option<&StdError> {
+        fn cause(&self) -> Option<&dyn StdError> {
             None
         }
     }

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -430,7 +430,7 @@ where {
             &account_packet_id
         ));
 
-        let (net_tx, net_rx) = mpsc::unbounded::<NetworkEvent>();
+        let (_net_tx, _net_rx) = mpsc::unbounded::<NetworkEvent>();
 
         let mut client_inner = self.inner.borrow_mut();
 
@@ -465,8 +465,8 @@ where {
                     Response::Mutation(res) => res.map_err(CoreError::from),
                     _ => Err(CoreError::from("Unexpected response")),
                 })
-                .and_then(move |resp| cm4.disconnect(&account_pub_id2))
-                .and_then(move |resp| cm5.bootstrap(client_full_id))
+                .and_then(move |_| cm4.disconnect(&account_pub_id2))
+                .and_then(move |_| cm5.bootstrap(client_full_id))
                 .map_err(AuthError::from),
         )
     }

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.32.1"
 bincode = "~1.1.4"
 bytes = { version = "~0.4.12", features = ["serde"] }
 chrono = { version = "~0.4.0", features = ["serde"] }
-config_file_handler = "~0.11.0"
 crossbeam-channel = "~0.3.9"
 data-encoding = "~2.1.1"
 directories = "~2.0.2"

--- a/safe_core/sample_config/safe_core.default.config
+++ b/safe_core/sample_config/safe_core.default.config
@@ -7,7 +7,7 @@
     "idle_timeout_msec": null,
     "keep_alive_interval_msec": null,
     "our_complete_cert": null,
-    "our_type": "Node"
+    "our_type": "Client"
   },
   "dev": null
 }

--- a/safe_core/sample_config/safe_core.default.config
+++ b/safe_core/sample_config/safe_core.default.config
@@ -1,0 +1,13 @@
+{
+  "quic_p2p": {
+    "hard_coded_contacts": [],
+    "port": null,
+    "ip": null,
+    "max_msg_size_allowed": null,
+    "idle_timeout_msec": null,
+    "keep_alive_interval_msec": null,
+    "our_complete_cert": null,
+    "our_type": "Node"
+  },
+  "dev": null
+}

--- a/safe_core/sample_config/sample_disk.safe_core.config
+++ b/safe_core/sample_config/sample_disk.safe_core.config
@@ -1,7 +1,0 @@
-{
-  "dev": {
-    "mock_unlimited_mutations": false,
-    "mock_in_memory_storage": false,
-    "mock_vault_path": "./tmp"
-  }
-}

--- a/safe_core/sample_config/sample_memory.safe_core.config
+++ b/safe_core/sample_config/sample_memory.safe_core.config
@@ -1,6 +1,0 @@
-{
-  "dev": {
-    "mock_unlimited_mutations": true,
-    "mock_in_memory_storage": true
-  }
-}

--- a/safe_core/src/config_handler.rs
+++ b/safe_core/src/config_handler.rs
@@ -11,15 +11,11 @@ use directories::ProjectDirs;
 use quic_p2p::Config as QuicP2pConfig;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[cfg(test)]
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 use std::{
-    ffi::OsString,
     fs::File,
     io::{self, BufReader},
 };
-
-// TODO: Currently the quic-p2p and dev config are handled through different mechanisms. We need to
-// unify and streamline, in the process getting rid of config_file_handler.
 
 const CONFIG_DIR_QUALIFIER: &str = "net";
 const CONFIG_DIR_ORGANISATION: &str = "MaidSafe";
@@ -115,81 +111,36 @@ where
 
 /// Writes a `safe_core` config file **for use by tests and examples**.
 ///
-/// The file is written to the [`current_bin_dir()`](file_handler/fn.current_bin_dir.html)
-/// with the appropriate file name.
+/// The file is written to the `current_bin_dir()` with the appropriate file name.
+///
+/// N.B. This method should only be used as a utility for test and examples.  In normal use cases,
+/// the config file should be created by the Vault's installer.
 #[cfg(test)]
+#[allow(unused)]
 pub fn write_config_file(config: &Config) -> Result<PathBuf, CoreError> {
-    let mut config_path = PathBuf::new();
-    config_path.push(get_file_name()?);
-    Ok(config_path)
-    // use std::io::Write;
+    let dirs = dirs()?;
+    let dir = dirs.config_dir();
+    fs::create_dir_all(dir)?;
 
-    // let mut config_path = config_file_handler::current_bin_dir()?;
-    // config_path.push(get_file_name()?);
-    // let mut file = ::std::fs::File::create(&config_path)?;
-    // write!(
-    //     &mut file,
-    //     "{}",
-    //     unwrap!(serde_json::to_string_pretty(config))
-    // )?;
-    // file.sync_all()?;
-    // Ok(config_path)
-}
+    let path = dir.join(CONFIG_FILE);
+    dbg!(&path);
+    let mut file = File::create(&path)?;
+    serde_json::to_writer_pretty(&mut file, config)?;
+    file.sync_all()?;
 
-fn get_file_name() -> Result<OsString, CoreError> {
-    let mut name = config_file_handler::exe_file_stem()?;
-    name.push(".safe_core.config");
-    Ok(name)
+    Ok(path)
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use serde_json;
-    use std::fs::File;
-    use std::io::Read;
-    use std::path::Path;
 
+    // Write a default config file for use as reference. This will overwrite any existing
+    // configurations so use with care.
     #[test]
-    fn parse_sample_config_file_memory() {
-        let path = Path::new("sample_config/sample_memory.safe_core.config").to_path_buf();
-        let mut file = unwrap!(File::open(&path), "Error opening {}:", path.display());
-        let mut encoded_contents = String::new();
-        let _ = unwrap!(
-            file.read_to_string(&mut encoded_contents),
-            "Error reading {}:",
-            path.display()
-        );
-        let config: Config = unwrap!(
-            serde_json::from_str(&encoded_contents),
-            "Error parsing {} as JSON:",
-            path.display()
-        );
-
-        let dev_config = unwrap!(config.dev, "{} is missing `dev` field.", path.display());
-        assert_eq!(dev_config.mock_unlimited_mutations, true);
-        assert_eq!(dev_config.mock_in_memory_storage, true);
-    }
-
-    #[test]
-    fn parse_sample_config_file_disk() {
-        let path = Path::new("sample_config/sample_disk.safe_core.config").to_path_buf();
-        let mut file = unwrap!(File::open(&path), "Error opening {}:", path.display());
-        let mut encoded_contents = String::new();
-        let _ = unwrap!(
-            file.read_to_string(&mut encoded_contents),
-            "Error reading {}:",
-            path.display()
-        );
-        let config: Config = unwrap!(
-            serde_json::from_str(&encoded_contents),
-            "Error parsing {} as JSON:",
-            path.display()
-        );
-
-        let dev_config = unwrap!(config.dev, "{} is missing `dev` field.", path.display());
-        assert_eq!(dev_config.mock_unlimited_mutations, false);
-        assert_eq!(dev_config.mock_in_memory_storage, false);
-        assert_eq!(dev_config.mock_vault_path, Some(String::from("./tmp")));
+    #[ignore]
+    fn write_default_config_file() {
+        let config = Config::default();
+        unwrap!(write_config_file(&config));
     }
 }

--- a/safe_core/src/connection_manager.rs
+++ b/safe_core/src/connection_manager.rs
@@ -38,7 +38,7 @@ pub struct ConnectionManager {
 
 impl ConnectionManager {
     /// Create a new connection manager.
-    pub fn new(config: QuicP2pConfig, net_tx: &NetworkTx) -> Result<Self, CoreError> {
+    pub fn new(config: QuicP2pConfig, _net_tx: &NetworkTx) -> Result<Self, CoreError> {
         // config.idle_timeout_msec = Some(0);
 
         let (event_tx, event_rx) = crossbeam_channel::unbounded();
@@ -160,7 +160,6 @@ impl Drop for Inner {
         trace!("Dropped ConnectionManager - terminating gracefully");
 
         let groups = mem::replace(&mut self.groups, Default::default());
-        let groups_num = groups.len();
         for (_pub_id, mut group) in groups.into_iter() {
             group.terminate();
         }
@@ -252,7 +251,7 @@ impl Inner {
             .map(|group| group.handle_unsent_user_message(peer_addr, msg, token));
     }
 
-    fn handle_connected_to(&mut self, peer: Peer) {
+    fn handle_connected_to(&mut self, _peer: Peer) {
         // TODO
     }
 

--- a/safe_core/src/connection_manager/connection_group.rs
+++ b/safe_core/src/connection_manager/connection_group.rs
@@ -150,7 +150,7 @@ impl ConnectionGroup {
         );
     }
 
-    pub fn handle_sent_user_message(&mut self, peer_addr: SocketAddr, msg: Bytes, token: Token) {
+    pub fn handle_sent_user_message(&mut self, _peer_addr: SocketAddr, _msg: Bytes, _token: Token) {
         // TODO: check if we have handled the challenge?
         trace!("{}: Sent user message", self.id);
     }
@@ -162,7 +162,7 @@ impl ConnectionGroup {
             Ok(Message::Request {
                 request,
                 message_id,
-                signature,
+                signature: _,
             }) => self.handle_unsent_request(peer_addr, request, message_id, token),
             Ok(_) => println!("Unexpected message type"),
             Err(e) => println!("Unexpected error {:?}", e),
@@ -171,10 +171,10 @@ impl ConnectionGroup {
 
     fn handle_unsent_request(
         &mut self,
-        peer_addr: SocketAddr,
-        request: Request,
-        message_id: MessageId,
-        token: Token,
+        _peer_addr: SocketAddr,
+        _request: Request,
+        _message_id: MessageId,
+        _token: Token,
     ) {
         trace!("{}: Not sent user message", self.id);
         // TODO: unimplemented

--- a/safe_core/src/lib.rs
+++ b/safe_core/src/lib.rs
@@ -73,8 +73,6 @@
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-#[cfg(test)]
-extern crate serde_json;
 #[macro_use]
 extern crate unwrap;
 


### PR DESCRIPTION
Remove obsolete and unused config file handling code, and then remove unused `config_file_handler` crate.