### PR TITLE
chore/all: rename temporarily named entities

### DIFF
--- a/safe_app/src/client.rs
+++ b/safe_app/src/client.rs
@@ -12,7 +12,7 @@ use crate::{AppContext, AppMsgTx};
 use lru_cache::LruCache;
 use routing::FullId;
 use rust_sodium::crypto::{box_, sign};
-use safe_core::client::{ClientInner, NewFullId, IMMUT_DATA_CACHE_SIZE}; //, REQUEST_TIMEOUT_SECS};
+use safe_core::client::{ClientInner, SafeKey, IMMUT_DATA_CACHE_SIZE}; //, REQUEST_TIMEOUT_SECS};
 use safe_core::config_handler::Config;
 use safe_core::crypto::{shared_box, shared_secretbox, shared_sign};
 use safe_core::ipc::BootstrapConfig;
@@ -47,7 +47,7 @@ impl AppClient {
 
         let mut connection_manager =
             ConnectionManager::new(Config::new().quic_p2p, &net_tx.clone())?;
-        block_on_all(connection_manager.bootstrap(NewFullId::app(
+        block_on_all(connection_manager.bootstrap(SafeKey::app(
             client_keys.clone().into_app_full_id(client_pk),
         )))?;
 
@@ -131,7 +131,7 @@ impl AppClient {
         let mut connection_manager =
             ConnectionManager::new(Config::new().quic_p2p, &net_tx.clone())?;
         let _ = block_on_all(
-            connection_manager.bootstrap(NewFullId::app(keys.clone().into_app_full_id(owner))),
+            connection_manager.bootstrap(SafeKey::app(keys.clone().into_app_full_id(owner))),
         );
 
         // let (mut routing, routing_rx) = setup_routing(

--- a/safe_app/src/errors.rs
+++ b/safe_app/src/errors.rs
@@ -432,7 +432,7 @@ fn core_error_code(err: &CoreError) -> i32 {
             ClientError::InvalidInvitation => ERR_INVALID_INVITATION,
             ClientError::InvitationAlreadyClaimed => ERR_INVITATION_ALREADY_CLAIMED,
         },
-        CoreError::NewRoutingClientError(ref err) => match *err {
+        CoreError::DataError(ref err) => match *err {
             SndError::AccessDenied => ERR_ACCESS_DENIED,
             SndError::NoSuchLoginPacket => ERR_NO_SUCH_LOGIN_PACKET,
             SndError::LoginPacketExists => ERR_LOGIN_PACKET_EXISTS,

--- a/safe_app/src/ffi/mutable_data/mod.rs
+++ b/safe_app/src/ffi/mutable_data/mod.rs
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn mdata_get_version(
         let info = NativeMDataInfo::clone_from_repr_c(info)?;
 
         send(app, user_data, o_cb, move |client, _| {
-            client.get_mdata_version_new(*info.address())
+            client.get_mdata_version(*info.address())
         })
     })
 }
@@ -244,7 +244,7 @@ pub unsafe extern "C" fn mdata_list_keys(
 
         (*app).send(move |client, _context| {
             client
-                .list_mdata_keys_new(*info.address())
+                .list_mdata_keys(*info.address())
                 .map_err(AppError::from)
                 .then(move |result| {
                     match result {
@@ -378,7 +378,7 @@ pub unsafe extern "C" fn mdata_list_permissions(
             let context = context.clone();
 
             client
-                .list_mdata_permissions_new(*info.address())
+                .list_mdata_permissions(*info.address())
                 .map(move |perms| helper::insert_permissions(context.object_cache(), perms))
         })
     })
@@ -411,7 +411,7 @@ pub unsafe extern "C" fn mdata_list_user_permissions(
             );
 
             client
-                .list_mdata_user_permissions_new(*info.address(), user)
+                .list_mdata_user_permissions(*info.address(), user)
                 .map(move |set| {
                     let perm_set = permission_set_into_repr_c(set);
                     o_cb(user_data.0, FFI_RESULT_OK, &perm_set);
@@ -453,7 +453,7 @@ pub unsafe extern "C" fn mdata_set_user_permissions(
             let permission_set = unwrap!(permission_set_clone_from_repr_c(permission_set));
 
             client
-                .set_mdata_user_permissions_new(*info.address(), user, permission_set, version)
+                .set_mdata_user_permissions(*info.address(), user, permission_set, version)
                 .map_err(AppError::from)
                 .then(move |result| {
                     call_result_cb!(result, user_data, o_cb);
@@ -489,7 +489,7 @@ pub unsafe extern "C" fn mdata_del_user_permissions(
             );
 
             client
-                .del_mdata_user_permissions_new(*info.address(), user, version)
+                .del_mdata_user_permissions(*info.address(), user, version)
                 .map_err(AppError::from)
                 .then(move |result| {
                     call_result_cb!(result, user_data, o_cb);

--- a/safe_app/src/tests/append_only_data.rs
+++ b/safe_app/src/tests/append_only_data.rs
@@ -64,7 +64,7 @@ fn data_created_by_an_app() {
                 .put_adata(invalid_data)
                 .then(move |res| {
                     match res {
-                        Err(CoreError::NewRoutingClientError(SndError::InvalidOwners)) => (),
+                        Err(CoreError::DataError(SndError::InvalidOwners)) => (),
                         Ok(_) => panic!("{:?}: Unexpected success", variant),
                         Err(err) => panic!("{:?}: Unexpected error {:?}", variant, err),
                     }
@@ -165,8 +165,8 @@ fn managing_permissions_for_an_app() {
                     match res {
                         // FIXME: we should expect only `AccessDenied` here, but due to
                         // a discrepancy in the way it's handled by mock/non-mock vaults we cover both errors
-                        Err(CoreError::NewRoutingClientError(SndError::AccessDenied))
-                        | Err(CoreError::NewRoutingClientError(SndError::InvalidPermissions)) => (),
+                        Err(CoreError::DataError(SndError::AccessDenied))
+                        | Err(CoreError::DataError(SndError::InvalidPermissions)) => (),
                         res => panic!("{:?}: Unexpected result: {:?}", variant, res),
                     }
                     // Signal the client to allow access to the data
@@ -391,7 +391,7 @@ fn restricted_access_and_deletion() {
                             assert_eq!(*data.address(), address);
                             assert_eq!(data.entries_index(), 3);
                         }
-                        (Err(CoreError::NewRoutingClientError(SndError::AccessDenied)), false) => {}
+                        (Err(CoreError::DataError(SndError::AccessDenied)), false) => {}
                         (res, _) => panic!("{:?}: Unexpected result: {:?}", variant, res),
                     }
                     // Send the app's key so it can be authenticated and granted access to the data
@@ -428,7 +428,7 @@ fn restricted_access_and_deletion() {
                 })
                 .then(move |res| {
                     match res {
-                        Err(CoreError::NewRoutingClientError(SndError::AccessDenied)) => (),
+                        Err(CoreError::DataError(SndError::AccessDenied)) => (),
                         res => panic!("{:?}: Unexpected result: {:?}", variant, res),
                     }
                     client5.get_adata(address)
@@ -436,7 +436,7 @@ fn restricted_access_and_deletion() {
                 .then(move |res| {
                     match (res, address.is_pub()) {
                         (Ok(data), true) => assert_eq!(*data.address(), address),
-                        (Err(CoreError::NewRoutingClientError(SndError::AccessDenied)), false) => {}
+                        (Err(CoreError::DataError(SndError::AccessDenied)), false) => {}
                         (res, _) => panic!("{:?}: Unexpected result: {:?}", variant, res),
                     }
                     unwrap!(finish_tx.send(()));
@@ -532,10 +532,7 @@ fn restricted_access_and_deletion() {
                     })
                     .then(move |res| {
                         match (res, address.is_pub()) {
-                            (
-                                Err(CoreError::NewRoutingClientError(SndError::InvalidOperation)),
-                                true,
-                            ) => (),
+                            (Err(CoreError::DataError(SndError::InvalidOperation)), true) => (),
                             (Ok(()), false) => (),
                             (res, _) => panic!("{:?}: Unexpected result: {:?}", variant, res),
                         }
@@ -635,7 +632,7 @@ fn public_permissions_with_app_restrictions() {
                 })
                 .then(move |res| {
                     match res {
-                        Err(CoreError::NewRoutingClientError(SndError::AccessDenied)) => (),
+                        Err(CoreError::DataError(SndError::AccessDenied)) => (),
                         res => panic!("{:?}: Unexpected result: {:?}", variant, res),
                     }
                     let permissions = BTreeMap::new();
@@ -651,7 +648,7 @@ fn public_permissions_with_app_restrictions() {
                 })
                 .then(move |res| {
                     match res {
-                        Err(CoreError::NewRoutingClientError(SndError::AccessDenied)) => (),
+                        Err(CoreError::DataError(SndError::AccessDenied)) => (),
                         res => panic!("{:?}: Unexpected result: {:?}", variant, res),
                     }
                     client6.get_adata(address)

--- a/safe_app/src/tests/coins.rs
+++ b/safe_app/src/tests/coins.rs
@@ -40,7 +40,7 @@ fn coin_app_deny_permissions() {
             .get_balance(None)
             .then(move |res| {
                 match res {
-                    Err(CoreError::NewRoutingClientError(Error::AccessDenied)) => (),
+                    Err(CoreError::DataError(Error::AccessDenied)) => (),
                     res => panic!("Unexpected result: {:?}", res),
                 }
 
@@ -53,7 +53,7 @@ fn coin_app_deny_permissions() {
             })
             .then(move |res| {
                 match res {
-                    Err(CoreError::NewRoutingClientError(Error::AccessDenied)) => (),
+                    Err(CoreError::DataError(Error::AccessDenied)) => (),
                     res => panic!("Unexpected result: {:?}", res),
                 }
                 Ok::<_, AppError>(())

--- a/safe_app/src/tests/mod.rs
+++ b/safe_app/src/tests/mod.rs
@@ -335,7 +335,7 @@ fn unregistered_client() {
                     .get_adata(ADataAddress::UnpubUnseq { name: addr, tag })
                     .then(|res| {
                         match res {
-                            Err(CoreError::NewRoutingClientError(SndError::AccessDenied)) => (),
+                            Err(CoreError::DataError(SndError::AccessDenied)) => (),
                             res => panic!("Unexpected result {:?}", res),
                         }
                         Ok(())

--- a/safe_app/src/tests/unpublished_mutable_data.rs
+++ b/safe_app/src/tests/unpublished_mutable_data.rs
@@ -55,7 +55,7 @@ fn md_created_by_app_1() {
             .then(move |res| {
                 match res {
                     Ok(()) => panic!("It should fail"),
-                    Err(CoreError::NewRoutingClientError(Error::AccessDenied)) => (),
+                    Err(CoreError::DataError(Error::AccessDenied)) => (),
                     Err(x) => panic!("Expected Error::AccessDenied. Got {:?}", x),
                 }
                 let user = bls_pk;
@@ -73,7 +73,7 @@ fn md_created_by_app_1() {
             .then(move |res| -> Result<_, ()> {
                 match res {
                     Ok(()) => panic!("It should fail"),
-                    Err(CoreError::NewRoutingClientError(Error::AccessDenied)) => (),
+                    Err(CoreError::DataError(Error::AccessDenied)) => (),
                     Err(x) => panic!("Expected Error::AccessDenied. Got {:?}", x),
                 }
                 unwrap!(tx.send(()));
@@ -159,7 +159,7 @@ fn md_created_by_app_2() {
             .then(move |res| {
                 match res {
                     Ok(()) => panic!("It should fail"),
-                    Err(CoreError::NewRoutingClientError(Error::AccessDenied)) => (),
+                    Err(CoreError::DataError(Error::AccessDenied)) => (),
                     Err(x) => panic!("Expected Error::AccessDenied. Got {:?}", x),
                 }
                 let entry_actions =
@@ -169,7 +169,7 @@ fn md_created_by_app_2() {
             .then(move |res| {
                 match res {
                     Ok(()) => panic!("It should fail"),
-                    Err(CoreError::NewRoutingClientError(Error::AccessDenied)) => (),
+                    Err(CoreError::DataError(Error::AccessDenied)) => (),
                     Err(x) => panic!("Expected Error::AccessDenied. Got {:?}", x),
                 }
                 let user = app_bls_key;
@@ -201,7 +201,7 @@ fn md_created_by_app_2() {
             .then(move |res| {
                 match res {
                     Ok(()) => panic!("It should fail"),
-                    Err(CoreError::NewRoutingClientError(Error::AccessDenied)) => (),
+                    Err(CoreError::DataError(Error::AccessDenied)) => (),
                     Err(x) => panic!("Expected Error::AccessDenied. Got {:?}", x),
                 }
                 let entry_actions = MDataUnseqEntryActions::new().del(vec![1, 2, 3, 4]);
@@ -273,7 +273,7 @@ fn md_created_by_app_3() {
             .then(move |res| {
                 match res {
                     Ok(()) => panic!("Put should be rejected by MaidManagers"),
-                    Err(CoreError::NewRoutingClientError(Error::InvalidOwners)) => (),
+                    Err(CoreError::DataError(Error::InvalidOwners)) => (),
                     Err(x) => panic!("Expected ClientError::InvalidOwners. Got {:?}", x),
                 }
                 let owners = c2.owner_key();
@@ -399,7 +399,7 @@ fn multiple_apps() {
             .then(move |res| -> Result<_, ()> {
                 match res {
                     Ok(()) => panic!("It should fail"),
-                    Err(CoreError::NewRoutingClientError(Error::AccessDenied)) => (),
+                    Err(CoreError::DataError(Error::AccessDenied)) => (),
                     Err(x) => panic!("Expected Error::AccessDenied. Got {:?}", x),
                 }
                 unwrap!(final_check_tx.send(()));
@@ -467,7 +467,7 @@ fn permissions_and_version() {
             .then(move |res| {
                 match res {
                     Ok(()) => panic!("It should fail with invalid successor"),
-                    Err(CoreError::NewRoutingClientError(Error::InvalidSuccessor(..))) => (),
+                    Err(CoreError::DataError(Error::InvalidSuccessor(..))) => (),
                     Err(x) => panic!("Expected Error::InvalidSuccessor. Got {:?}", x),
                 }
                 c4.list_mdata_permissions_new(MDataAddress::Unseq { name, tag: DIR_TAG })

--- a/safe_app/src/tests/unpublished_mutable_data.rs
+++ b/safe_app/src/tests/unpublished_mutable_data.rs
@@ -60,7 +60,7 @@ fn md_created_by_app_1() {
                 }
                 let user = bls_pk;
                 let permissions = MDataPermissionSet::new().allow(MDataAction::Update);
-                c3.set_mdata_user_permissions_new(
+                c3.set_mdata_user_permissions(
                     MDataAddress::Seq {
                         name: name2,
                         tag: DIR_TAG,
@@ -176,7 +176,7 @@ fn md_created_by_app_2() {
                 let permissions = MDataPermissionSet::new()
                     .allow(MDataAction::Insert)
                     .allow(MDataAction::Delete);
-                c3.set_mdata_user_permissions_new(
+                c3.set_mdata_user_permissions(
                     MDataAddress::Unseq {
                         name: name2,
                         tag: DIR_TAG,
@@ -349,7 +349,7 @@ fn multiple_apps() {
                         version: 0
                     }
                 );
-                c3.del_mdata_user_permissions_new(
+                c3.del_mdata_user_permissions(
                     MDataAddress::Seq {
                         name: name2,
                         tag: DIR_TAG,
@@ -363,7 +363,7 @@ fn multiple_apps() {
                 let entry_key = unwrap!(res);
                 unwrap!(mutate_again_tx.send(()));
                 unwrap!(final_check_rx.recv());
-                c4.list_mdata_keys_new(MDataAddress::Seq {
+                c4.list_mdata_keys(MDataAddress::Seq {
                     name: name3,
                     tag: DIR_TAG,
                 })
@@ -449,7 +449,7 @@ fn permissions_and_version() {
             .then(move |res| {
                 unwrap!(res);
                 let permissions = MDataPermissionSet::new().allow(MDataAction::Update);
-                c2.set_mdata_user_permissions_new(
+                c2.set_mdata_user_permissions(
                     MDataAddress::Unseq { name, tag: DIR_TAG },
                     PublicKey::from(random_key),
                     permissions,
@@ -458,7 +458,7 @@ fn permissions_and_version() {
             })
             .then(move |res| {
                 unwrap!(res);
-                c3.del_mdata_user_permissions_new(
+                c3.del_mdata_user_permissions(
                     MDataAddress::Unseq { name, tag: DIR_TAG },
                     PublicKey::from(random_key),
                     1,
@@ -470,7 +470,7 @@ fn permissions_and_version() {
                     Err(CoreError::DataError(Error::InvalidSuccessor(..))) => (),
                     Err(x) => panic!("Expected Error::InvalidSuccessor. Got {:?}", x),
                 }
-                c4.list_mdata_permissions_new(MDataAddress::Unseq { name, tag: DIR_TAG })
+                c4.list_mdata_permissions(MDataAddress::Unseq { name, tag: DIR_TAG })
             })
             .then(move |res| {
                 let permissions = unwrap!(res);
@@ -491,12 +491,12 @@ fn permissions_and_version() {
                     .is_allowed(MDataAction::Delete));
                 assert!(!unwrap!(permissions.get(&PublicKey::from(random_key)))
                     .is_allowed(MDataAction::ManagePermissions));
-                c5.get_mdata_version_new(MDataAddress::Unseq { name, tag: DIR_TAG })
+                c5.get_mdata_version(MDataAddress::Unseq { name, tag: DIR_TAG })
             })
             .then(move |res| {
                 let v = unwrap!(res);
                 assert_eq!(v, 1);
-                c6.del_mdata_user_permissions_new(
+                c6.del_mdata_user_permissions(
                     MDataAddress::Unseq { name, tag: DIR_TAG },
                     PublicKey::from(random_key),
                     v + 1,
@@ -504,7 +504,7 @@ fn permissions_and_version() {
             })
             .then(move |res| {
                 unwrap!(res);
-                c7.list_mdata_permissions_new(MDataAddress::Unseq { name, tag: DIR_TAG })
+                c7.list_mdata_permissions(MDataAddress::Unseq { name, tag: DIR_TAG })
             })
             .map(move |permissions| {
                 assert_eq!(permissions.len(), 1);
@@ -561,7 +561,7 @@ fn permissions_crud() {
                 let permissions = MDataPermissionSet::new()
                     .allow(MDataAction::Insert)
                     .allow(MDataAction::Delete);
-                c2.set_mdata_user_permissions_new(
+                c2.set_mdata_user_permissions(
                     MDataAddress::Unseq { name, tag: DIR_TAG },
                     PublicKey::from(random_key_a),
                     permissions,
@@ -570,7 +570,7 @@ fn permissions_crud() {
             })
             .then(move |res| {
                 unwrap!(res);
-                c3.list_mdata_permissions_new(MDataAddress::Unseq { name, tag: DIR_TAG })
+                c3.list_mdata_permissions(MDataAddress::Unseq { name, tag: DIR_TAG })
             })
             .then(move |res| {
                 {
@@ -599,7 +599,7 @@ fn permissions_crud() {
                 }
 
                 let permissions = MDataPermissionSet::new().allow(MDataAction::Delete);
-                c4.set_mdata_user_permissions_new(
+                c4.set_mdata_user_permissions(
                     MDataAddress::Unseq { name, tag: DIR_TAG },
                     PublicKey::from(random_key_b),
                     permissions,
@@ -608,7 +608,7 @@ fn permissions_crud() {
             })
             .then(move |res| {
                 unwrap!(res);
-                c5.list_mdata_permissions_new(MDataAddress::Unseq { name, tag: DIR_TAG })
+                c5.list_mdata_permissions(MDataAddress::Unseq { name, tag: DIR_TAG })
             })
             .then(move |res| {
                 {
@@ -643,7 +643,7 @@ fn permissions_crud() {
                 }
 
                 let permissions = MDataPermissionSet::new().allow(MDataAction::Insert);
-                c6.set_mdata_user_permissions_new(
+                c6.set_mdata_user_permissions(
                     MDataAddress::Unseq { name, tag: DIR_TAG },
                     PublicKey::from(random_key_b),
                     permissions,
@@ -652,7 +652,7 @@ fn permissions_crud() {
             })
             .then(move |res| {
                 unwrap!(res);
-                c7.del_mdata_user_permissions_new(
+                c7.del_mdata_user_permissions(
                     MDataAddress::Unseq { name, tag: DIR_TAG },
                     PublicKey::from(random_key_a),
                     4,
@@ -660,7 +660,7 @@ fn permissions_crud() {
             })
             .then(move |res| {
                 unwrap!(res);
-                cl8.list_mdata_permissions_new(MDataAddress::Unseq { name, tag: DIR_TAG })
+                cl8.list_mdata_permissions(MDataAddress::Unseq { name, tag: DIR_TAG })
             })
             .then(move |res| {
                 {
@@ -689,7 +689,7 @@ fn permissions_crud() {
                 let permissions = MDataPermissionSet::new()
                     .allow(MDataAction::Insert)
                     .allow(MDataAction::Delete);
-                c9.set_mdata_user_permissions_new(
+                c9.set_mdata_user_permissions(
                     MDataAddress::Unseq { name, tag: DIR_TAG },
                     PublicKey::from(random_key_b),
                     permissions,
@@ -698,7 +698,7 @@ fn permissions_crud() {
             })
             .then(move |res| {
                 unwrap!(res);
-                c10.list_mdata_permissions_new(MDataAddress::Unseq { name, tag: DIR_TAG })
+                c10.list_mdata_permissions(MDataAddress::Unseq { name, tag: DIR_TAG })
             })
             .then(move |res| -> Result<_, ()> {
                 {

--- a/safe_authenticator/src/access_container.rs
+++ b/safe_authenticator/src/access_container.rs
@@ -141,7 +141,7 @@ pub fn fetch_entry(
     client
         .get_seq_mdata_value(access_container.name(), access_container.type_tag(), key)
         .then(move |result| match result {
-            Err(CoreError::NewRoutingClientError(SndError::NoSuchEntry)) => Ok((0, None)),
+            Err(CoreError::DataError(SndError::NoSuchEntry)) => Ok((0, None)),
             Err(err) => Err(AuthError::from(err)),
             Ok(value) => {
                 let decoded = Some(decode_app_entry(&value.data, &app_keys.enc_key)?);

--- a/safe_authenticator/src/access_container.rs
+++ b/safe_authenticator/src/access_container.rs
@@ -177,11 +177,11 @@ pub fn put_entry(
     let app_pk: PublicKey = app_keys.bls_pk.into();
 
     client
-        .get_mdata_version_new(*access_container.address())
+        .get_mdata_version(*access_container.address())
         .map_err(AuthError::from)
         .and_then(move |shell_version| {
             client2
-                .set_mdata_user_permissions_new(
+                .set_mdata_user_permissions(
                     *acc_cont_info.address(),
                     app_pk,
                     MDataPermissionSet::new().allow(MDataAction::Read),
@@ -214,11 +214,11 @@ pub fn delete_entry(
     let app_pk: PublicKey = app_keys.bls_pk.into();
 
     client
-        .get_mdata_version_new(*access_container.address())
+        .get_mdata_version(*access_container.address())
         .map_err(AuthError::from)
         .and_then(move |shell_version| {
             client2
-                .del_mdata_user_permissions_new(*acc_cont_info.address(), app_pk, shell_version + 1)
+                .del_mdata_user_permissions(*acc_cont_info.address(), app_pk, shell_version + 1)
                 .map_err(AuthError::from)
         })
         .and_then(move |_| {

--- a/safe_authenticator/src/app_container.rs
+++ b/safe_authenticator/src/app_container.rs
@@ -50,9 +50,9 @@ pub fn fetch_or_create(
                         .allow(MDataAction::Delete)
                         .allow(MDataAction::ManagePermissions);
 
-                    c2.get_mdata_version_new(*mdata_info.address())
+                    c2.get_mdata_version(*mdata_info.address())
                         .and_then(move |version| {
-                            c2.set_mdata_user_permissions_new(
+                            c2.set_mdata_user_permissions(
                                 *mdata_info.address(),
                                 app_pk,
                                 ps,

--- a/safe_authenticator/src/apps.rs
+++ b/safe_authenticator/src/apps.rs
@@ -194,7 +194,7 @@ pub fn apps_accessing_mutable_data(
     let c2 = client.clone();
 
     client
-        .list_mdata_permissions_new(MDataAddress::Seq {
+        .list_mdata_permissions(MDataAddress::Seq {
             name,
             tag: type_tag,
         })

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -18,7 +18,7 @@ use routing::{FullId, XorName};
 use rust_sodium::crypto::sign::Seed;
 use rust_sodium::crypto::{box_, sign};
 use safe_core::client::account::Account;
-use safe_core::client::{req, AuthActions, ClientInner, NewFullId, IMMUT_DATA_CACHE_SIZE};
+use safe_core::client::{req, AuthActions, ClientInner, SafeKey, IMMUT_DATA_CACHE_SIZE};
 use safe_core::config_handler::Config;
 use safe_core::crypto::{shared_box, shared_secretbox, shared_sign};
 use safe_core::ipc::BootstrapConfig;
@@ -159,8 +159,8 @@ where {
         let transient_pk = transient_id.public_id().public_key();
         let new_login_packet = LoginPacket::new(acc_locator, *transient_pk, acc_ciphertext, sig)?;
 
-        let balance_full_id = NewFullId::client(ClientFullId::with_bls_key(balance_sk));
-        let client_full_id = NewFullId::client(maid_keys.into());
+        let balance_full_id = SafeKey::client(ClientFullId::with_bls_key(balance_sk));
+        let client_full_id = SafeKey::client(maid_keys.into());
 
         // Create the connection manager
         let mut connection_manager =
@@ -282,7 +282,7 @@ where {
 
         let client_full_id = create_client_id(&acc_locator.0);
         let client_pk = *client_full_id.public_id().public_key();
-        let client_full_id = NewFullId::client(client_full_id);
+        let client_full_id = SafeKey::client(client_full_id);
 
         let user_cred = UserCred::new(password, pin);
 
@@ -317,7 +317,7 @@ where {
             &user_cred.pin,
         )?;
 
-        let id_packet = NewFullId::client(acc.maid_keys.clone().into());
+        let id_packet = SafeKey::client(acc.maid_keys.clone().into());
 
         trace!("Creating an actual client...");
 
@@ -397,7 +397,7 @@ where {
         acc_loc: XorName,
         account: &Account,
         keys: &UserCred,
-        full_id: &NewFullId,
+        full_id: &SafeKey,
     ) -> Result<LoginPacket, AuthError> {
         let encrypted_account = account.encrypt(&keys.password, &keys.pin)?;
 
@@ -418,7 +418,7 @@ where {
         let keys = &auth_inner.user_cred;
         let client_full_id = auth_inner.full_id.clone();
         let acc_loc = &auth_inner.acc_loc;
-        let account_packet_id = NewFullId::client(create_client_id(&acc_loc.0));
+        let account_packet_id = SafeKey::client(create_client_id(&acc_loc.0));
         let account_pub_id = account_packet_id.public_id().clone();
         let updated_packet = fry!(Self::prepare_account_packet_update(
             *acc_loc,
@@ -596,7 +596,7 @@ struct AuthInner {
     acc: Account,
     acc_loc: XorName,
     user_cred: UserCred,
-    full_id: NewFullId,
+    full_id: SafeKey,
 }
 
 // ------------------------------------------------------------

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -623,7 +623,7 @@ mod tests {
     use safe_core::client::test_create_balance;
     use safe_core::utils::test_utils::{finish, random_client, setup_client};
     use safe_core::{utils, CoreError, DIR_TAG};
-    use safe_nd::{Coins, Error as SndError, MDataKind};
+    use safe_nd::{Coins, Error as SndError, IDataAddress, MDataKind};
     use std::str::FromStr;
     use tokio::runtime::current_thread::Runtime;
     use AuthMsgTx;
@@ -875,7 +875,7 @@ mod tests {
     #[test]
     fn timeout() {
         use crate::test_utils::random_client;
-        use safe_nd::{IDataAddress, PubImmutableData};
+        use safe_nd::PubImmutableData;
         use std::time::Duration;
 
         // Get

--- a/safe_authenticator/src/errors.rs
+++ b/safe_authenticator/src/errors.rs
@@ -369,7 +369,7 @@ fn core_error_code(err: &CoreError) -> i32 {
             ClientError::InvalidInvitation => ERR_INVALID_INVITATION,
             ClientError::InvitationAlreadyClaimed => ERR_INVITATION_ALREADY_CLAIMED,
         },
-        CoreError::NewRoutingClientError(ref err) => safe_nd_error_core(err),
+        CoreError::DataError(ref err) => safe_nd_error_core(err),
         CoreError::QuicP2p(ref _err) => ERR_QUIC_P2P, // FIXME: use proper error codes
         CoreError::UnsupportedSaltSizeForPwHash => ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH,
         CoreError::UnsuccessfulPwHash => ERR_UNSUCCESSFUL_PW_HASH,

--- a/safe_authenticator/src/ffi/ipc.rs
+++ b/safe_authenticator/src/ffi/ipc.rs
@@ -471,7 +471,7 @@ pub unsafe extern "C" fn encode_share_mdata_resp(
                             })
                             .buffer_unordered(num_mdata)
                             .map(move |(version, mdata)| {
-                                client_cloned1.set_mdata_user_permissions_new(
+                                client_cloned1.set_mdata_user_permissions(
                                     MDataAddress::Seq {
                                         name: mdata.name,
                                         tag: mdata.type_tag,

--- a/safe_authenticator/src/ipc.rs
+++ b/safe_authenticator/src/ipc.rs
@@ -120,7 +120,7 @@ pub fn update_container_perms(
                 let perm_set = container_perms_into_permission_set(&access);
 
                 let fut = client
-                    .get_mdata_version_new(*mdata_info.address())
+                    .get_mdata_version(*mdata_info.address())
                     .and_then(move |version| {
                         recovery::set_mdata_user_permissions(
                             &c2,

--- a/safe_authenticator/src/ipc.rs
+++ b/safe_authenticator/src/ipc.rs
@@ -186,7 +186,7 @@ pub fn decode_share_mdata_req(
                                         Err(_) => Err(ShareMDataError::InvalidMetadata),
                                     }
                                 })),
-                            Err(CoreError::NewRoutingClientError(SndError::NoSuchEntry)) => {
+                            Err(CoreError::DataError(SndError::NoSuchEntry)) => {
                                 // Allow requesting shared access to arbitrary Mutable Data objects even
                                 // if they don't have metadata.
                                 let user_metadata = UserMetadata {

--- a/safe_authenticator/src/revocation.rs
+++ b/safe_authenticator/src/revocation.rs
@@ -176,7 +176,7 @@ fn delete_app_auth_key(client: &AuthClient, key: PublicKey) -> Box<AuthFuture<()
             }
         })
         .or_else(|error| match error {
-            CoreError::NewRoutingClientError(SndError::NoSuchKey) => Ok(()),
+            CoreError::DataError(SndError::NoSuchKey) => Ok(()),
             error => Err(AuthError::from(error)),
         })
         .into_box()

--- a/safe_authenticator/src/revocation.rs
+++ b/safe_authenticator/src/revocation.rs
@@ -212,7 +212,7 @@ fn revoke_container_perms(
 
             client
                 .clone()
-                .get_mdata_version_new(*mdata_info.address())
+                .get_mdata_version(*mdata_info.address())
                 .and_then(move |version| {
                     recovery::del_mdata_user_permissions(
                         &c2,

--- a/safe_authenticator/src/std_dirs.rs
+++ b/safe_authenticator/src/std_dirs.rs
@@ -51,9 +51,7 @@ pub fn create(client: &AuthClient) -> Box<AuthFuture<()>> {
                     // Make sure that all default dirs have been created
                     create_std_dirs(&c3, &default_containers)
                 }
-                Err(AuthError::CoreError(CoreError::NewRoutingClientError(
-                    SndError::NoSuchData,
-                ))) => {
+                Err(AuthError::CoreError(CoreError::DataError(SndError::NoSuchData))) => {
                     // Access container hasn't been created yet
                     let access_cont_value = fry!(random_std_dirs())
                         .into_iter()

--- a/safe_authenticator/src/test_utils.rs
+++ b/safe_authenticator/src/test_utils.rs
@@ -394,7 +394,7 @@ pub fn compare_access_container_entries(
             assert_eq!(perms, expected_perms);
 
             let fut = client
-                .list_mdata_user_permissions_new(*md_info.address(), user)
+                .list_mdata_user_permissions(*md_info.address(), user)
                 .map(move |perms| (perms, expected_perm_set));
 
             reqs.push(fut);

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -276,9 +276,7 @@ mod mock_routing {
         // `Revoked` state (as it is listed in the config root, but not in the access
         // container)
         match test_utils::register_app(&auth, &auth_req) {
-            Err(AuthError::CoreError(CoreError::NewRoutingClientError(
-                SndError::InsufficientBalance,
-            ))) => (),
+            Err(AuthError::CoreError(CoreError::DataError(SndError::InsufficientBalance))) => (),
             x => panic!("Unexpected {:?}", x),
         }
 
@@ -316,9 +314,7 @@ mod mock_routing {
             cm_hook,
         ));
         match test_utils::register_app(&auth, &auth_req) {
-            Err(AuthError::CoreError(CoreError::NewRoutingClientError(
-                SndError::InsufficientBalance,
-            ))) => (),
+            Err(AuthError::CoreError(CoreError::DataError(SndError::InsufficientBalance))) => (),
             x => panic!("Unexpected {:?}", x),
         }
 
@@ -347,7 +343,7 @@ mod mock_routing {
             cm_hook,
         ));
         match test_utils::register_app(&auth, &auth_req) {
-            Err(AuthError::NfsError(NfsError::CoreError(CoreError::NewRoutingClientError(
+            Err(AuthError::NfsError(NfsError::CoreError(CoreError::DataError(
                 SndError::InsufficientBalance,
             )))) => (),
             x => panic!("Unexpected {:?}", x),
@@ -380,9 +376,7 @@ mod mock_routing {
             cm_hook,
         ));
         match test_utils::register_app(&auth, &auth_req) {
-            Err(AuthError::CoreError(CoreError::NewRoutingClientError(
-                SndError::InsufficientBalance,
-            ))) => (),
+            Err(AuthError::CoreError(CoreError::DataError(SndError::InsufficientBalance))) => (),
             x => panic!("Unexpected {:?}", x),
         }
 

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -406,13 +406,13 @@ mod mock_routing {
             let c2 = client.clone();
 
             client
-                .get_mdata_version_new(*app_container.address())
+                .get_mdata_version(*app_container.address())
                 .then(move |res| {
                     let version = unwrap!(res);
                     assert_eq!(version, 0);
 
                     // Check that the app's container has required permissions.
-                    c2.list_mdata_permissions_new(*app_container.address())
+                    c2.list_mdata_permissions(*app_container.address())
                 })
                 .then(move |res| {
                     let perms = unwrap!(res);
@@ -450,7 +450,7 @@ fn test_access_container() {
             .into_iter()
             .map(|(_, dir)| {
                 let f1 = client.list_seq_mdata_entries(dir.name(), dir.type_tag());
-                let f2 = client.list_mdata_permissions_new(*dir.address());
+                let f2 = client.list_mdata_permissions(*dir.address());
 
                 f1.join(f2).map_err(AuthError::from)
             })

--- a/safe_authenticator/src/tests/revocation.rs
+++ b/safe_authenticator/src/tests/revocation.rs
@@ -67,7 +67,7 @@ fn verify_app_is_revoked(
         .and_then(move |app_key| {
             let futures = prev_ac_entry.into_iter().map(move |(_, (mdata_info, _))| {
                 // Verify the app has no permissions in the containers.
-                c1.list_mdata_user_permissions_new(*mdata_info.address(), app_key)
+                c1.list_mdata_user_permissions(*mdata_info.address(), app_key)
                     .then(|res| {
                         assert_match!(res, Err(CoreError::DataError(SndError::NoSuchKey)));
                         Ok(())
@@ -117,7 +117,7 @@ fn verify_app_is_authenticated(client: &AuthClient, app_id: String) -> Box<AuthF
                     // Verify the app has the permissions set according to the access container.
                     let expected_perms = container_perms_into_permission_set(&permissions);
                     let perms = c2
-                        .list_mdata_user_permissions_new(*mdata_info.address(), user)
+                        .list_mdata_user_permissions(*mdata_info.address(), user)
                         .then(move |res| {
                             let perms = unwrap!(res);
                             assert_eq!(perms, expected_perms);
@@ -771,7 +771,7 @@ fn app_revocation_and_reauth() {
     let (name, tag) = (videos_md2.name(), videos_md2.type_tag());
     let perms = unwrap!(run(&authenticator, move |client| {
         client
-            .list_mdata_permissions_new(MDataAddress::Seq { name, tag })
+            .list_mdata_permissions(MDataAddress::Seq { name, tag })
             .map_err(From::from)
     }));
     assert!(!perms.contains_key(&PublicKey::from(auth_granted1.app_keys.bls_pk)));

--- a/safe_authenticator/src/tests/revocation.rs
+++ b/safe_authenticator/src/tests/revocation.rs
@@ -69,10 +69,7 @@ fn verify_app_is_revoked(
                 // Verify the app has no permissions in the containers.
                 c1.list_mdata_user_permissions_new(*mdata_info.address(), app_key)
                     .then(|res| {
-                        assert_match!(
-                            res,
-                            Err(CoreError::NewRoutingClientError(SndError::NoSuchKey))
-                        );
+                        assert_match!(res, Err(CoreError::DataError(SndError::NoSuchKey)));
                         Ok(())
                     })
             });

--- a/safe_authenticator/src/tests/serialisation.rs
+++ b/safe_authenticator/src/tests/serialisation.rs
@@ -141,7 +141,7 @@ fn verify_std_dirs(
         .chain(DEFAULT_PRIVATE_DIRS.iter())
         .map(|expected_container| {
             let mi = unwrap!(actual_containers.get(*expected_container));
-            client.get_mdata_version_new(*mi.address())
+            client.get_mdata_version(*mi.address())
         })
         .collect();
 

--- a/safe_core/src/client/core_client.rs
+++ b/safe_core/src/client/core_client.rs
@@ -9,7 +9,7 @@
 use crate::client::account::{Account as ClientAccount, ClientKeys};
 #[cfg(feature = "mock-network")]
 use crate::client::mock::ConnectionManager;
-use crate::client::{req, AuthActions, Client, ClientInner, NewFullId, IMMUT_DATA_CACHE_SIZE};
+use crate::client::{req, AuthActions, Client, ClientInner, SafeKey, IMMUT_DATA_CACHE_SIZE};
 use crate::config_handler::Config;
 #[cfg(not(feature = "mock-network"))]
 use crate::connection_manager::ConnectionManager;
@@ -105,7 +105,7 @@ impl CoreClient {
             let client_full_id = ClientFullId::new_bls(&mut rng);
             (
                 *client_full_id.public_id().public_key(),
-                NewFullId::client(client_full_id),
+                SafeKey::client(client_full_id),
             )
         };
 
@@ -115,7 +115,7 @@ impl CoreClient {
         let balance_client_id = ClientFullId::with_bls_key(balance_sk);
         let new_balance_owner = *balance_client_id.public_id().public_key();
 
-        let balance_client_id = NewFullId::client(balance_client_id);
+        let balance_client_id = SafeKey::client(balance_client_id);
         let balance_pub_id = balance_client_id.public_id();
 
         // Create the connection manager
@@ -156,7 +156,7 @@ impl CoreClient {
             block_on_all(connection_manager.disconnect(&balance_pub_id))?;
         }
 
-        block_on_all(connection_manager.bootstrap(NewFullId::client(maid_keys.clone().into())))?;
+        block_on_all(connection_manager.bootstrap(SafeKey::client(maid_keys.clone().into())))?;
 
         Ok(Self {
             inner: Rc::new(RefCell::new(ClientInner {

--- a/safe_core/src/client/id.rs
+++ b/safe_core/src/client/id.rs
@@ -11,39 +11,37 @@ use std::sync::Arc;
 
 /// An enum representing the Full Id variants for a Client or App
 #[derive(Clone)]
-pub enum NewFullId {
+pub enum SafeKey {
     /// Represents an application authorised by a client.
     App(Arc<AppFullId>),
     /// Represents a network client.
     Client(Arc<ClientFullId>),
 }
 
-impl NewFullId {
+impl SafeKey {
     /// Create a client full ID.
     pub fn client(full_id: ClientFullId) -> Self {
-        NewFullId::Client(Arc::new(full_id))
+        SafeKey::Client(Arc::new(full_id))
     }
 
     /// Create an app full ID.
     pub fn app(full_id: AppFullId) -> Self {
-        NewFullId::App(Arc::new(full_id))
+        SafeKey::App(Arc::new(full_id))
     }
 
     /// Sign a given message using the App / Client full id as required.
     pub fn sign(&self, msg: &[u8]) -> Signature {
         match self {
-            NewFullId::App(app_full_id) => app_full_id.sign(msg),
-            NewFullId::Client(client_full_id) => client_full_id.sign(msg),
+            SafeKey::App(app_full_id) => app_full_id.sign(msg),
+            SafeKey::Client(client_full_id) => client_full_id.sign(msg),
         }
     }
 
     /// Return a corresponding public ID.
     pub fn public_id(&self) -> PublicId {
         match self {
-            NewFullId::App(app_full_id) => PublicId::App(app_full_id.public_id().clone()),
-            NewFullId::Client(client_full_id) => {
-                PublicId::Client(client_full_id.public_id().clone())
-            }
+            SafeKey::App(app_full_id) => PublicId::App(app_full_id.public_id().clone()),
+            SafeKey::Client(client_full_id) => PublicId::Client(client_full_id.public_id().clone()),
         }
     }
 }

--- a/safe_core/src/client/mock/connection_manager.rs
+++ b/safe_core/src/client/mock/connection_manager.rs
@@ -9,7 +9,7 @@
 use super::vault::{self, Vault};
 use crate::config_handler::{get_config, Config};
 use crate::{
-    client::NewFullId,
+    client::SafeKey,
     event::{NetworkEvent, NetworkTx},
     CoreError, CoreFuture,
 };
@@ -78,7 +78,7 @@ impl ConnectionManager {
     }
 
     /// Bootstrap to any known contact.
-    pub fn bootstrap(&mut self, full_id: NewFullId) -> Box<CoreFuture<()>> {
+    pub fn bootstrap(&mut self, full_id: SafeKey) -> Box<CoreFuture<()>> {
         let _ = unwrap!(self.groups.lock()).insert(full_id.public_id());
         ok!(())
     }

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -11,7 +11,7 @@
 
 use super::routing::Routing;
 use crate::client::mock::vault::Vault;
-use crate::client::NewFullId;
+use crate::client::SafeKey;
 use crate::config_handler::{Config, DevConfig};
 use crate::utils;
 
@@ -1780,14 +1780,14 @@ fn request_hooks() {
 }
 
 // Setup routing with a shared, global vault.
-fn setup() -> (Routing, Receiver<Event>, FullId, NewFullId) {
+fn setup() -> (Routing, Receiver<Event>, FullId, SafeKey) {
     let (routing, routing_rx, full_id, full_id_new) = setup_impl();
 
     (routing, routing_rx, full_id, full_id_new)
 }
 
 // Setup routing with a new, non-shared vault.
-fn setup_with_config(config: Config) -> (Routing, Receiver<Event>, FullId, NewFullId) {
+fn setup_with_config(config: Config) -> (Routing, Receiver<Event>, FullId, SafeKey) {
     let (mut routing, routing_rx, full_id, full_id_new) = setup_impl();
 
     routing.set_vault(&Arc::new(Mutex::new(Vault::new(config))));
@@ -1795,7 +1795,7 @@ fn setup_with_config(config: Config) -> (Routing, Receiver<Event>, FullId, NewFu
     (routing, routing_rx, full_id, full_id_new)
 }
 
-fn setup_impl() -> (Routing, Receiver<Event>, FullId, NewFullId) {
+fn setup_impl() -> (Routing, Receiver<Event>, FullId, SafeKey) {
     let full_id = FullId::new();
     let owner_pk = PublicKey::from(SecretKey::random().public_key());
     let app_full_id = AppFullId::with_keys(full_id.bls_key().clone(), owner_pk);
@@ -1814,7 +1814,7 @@ fn setup_impl() -> (Routing, Receiver<Event>, FullId, NewFullId) {
         e => panic!("Unexpected event {:?}", e),
     }
 
-    (routing, routing_rx, full_id, NewFullId::App(app_full_id))
+    (routing, routing_rx, full_id, SafeKey::App(app_full_id))
 }
 
 // Create a wallet for an account, and change the `PublicId` in routing to a Client variant
@@ -1823,7 +1823,7 @@ fn create_account(
     routing: &mut Routing,
     coins: Coins,
     owner_sk: &SecretKey,
-) -> (Authority<XorName>, NewFullId) {
+) -> (Authority<XorName>, SafeKey) {
     let owner_key: PublicKey = owner_sk.public_key().into();
     let account_name = XorName::from(owner_key);
     routing.create_balance(owner_key, coins);
@@ -1832,6 +1832,6 @@ fn create_account(
 
     (
         Authority::ClientManager(account_name),
-        NewFullId::Client(ClientFullId::with_bls_key(owner_sk.clone())),
+        SafeKey::Client(ClientFullId::with_bls_key(owner_sk.clone())),
     )
 }

--- a/safe_core/src/client/recovery.rs
+++ b/safe_core/src/client/recovery.rs
@@ -87,7 +87,7 @@ pub fn set_mdata_user_permissions(
 
     future::loop_fn(state, move |(attempts, version)| {
         client
-            .set_mdata_user_permissions_new(address, user, permissions.clone(), version)
+            .set_mdata_user_permissions(address, user, permissions.clone(), version)
             .map(|_| Loop::Break(()))
             .or_else(move |error| match error {
                 CoreError::DataError(SndError::InvalidSuccessor(current_version)) => {
@@ -122,7 +122,7 @@ pub fn del_mdata_user_permissions(
 
     future::loop_fn(state, move |(attempts, version)| {
         client
-            .del_mdata_user_permissions_new(address, user, version)
+            .del_mdata_user_permissions(address, user, version)
             .map(|_| Loop::Break(()))
             .or_else(move |error| match error {
                 CoreError::DataError(SndError::NoSuchKey) => Ok(Loop::Break(())),
@@ -152,8 +152,8 @@ fn update_mdata(client: &impl Client, data: SeqMutableData) -> Box<CoreFuture<()
 
     let address = *data.address();
     let f0 = client.list_seq_mdata_entries(*data.name(), data.tag());
-    let f1 = client.list_mdata_permissions_new(address);
-    let f2 = client.get_mdata_version_new(address);
+    let f1 = client.list_mdata_permissions(address);
+    let f2 = client.get_mdata_version(address);
 
     f0.join3(f1, f2)
         .and_then(move |(entries, permissions, version)| {
@@ -531,7 +531,7 @@ mod tests_with_mock_routing {
                         }
                     );
 
-                    client4.list_mdata_permissions_new(MDataAddress::Seq { name, tag })
+                    client4.list_mdata_permissions(MDataAddress::Seq { name, tag })
                 })
                 .then(move |res| {
                     let permissions = unwrap!(res);
@@ -692,7 +692,7 @@ mod tests_with_mock_routing {
                 })
                 .then(move |res| {
                     unwrap!(res);
-                    client3.list_mdata_user_permissions_new(address, user0)
+                    client3.list_mdata_user_permissions(address, user0)
                 })
                 .then(move |res| {
                     let retrieved_permissions = unwrap!(res);
@@ -706,7 +706,7 @@ mod tests_with_mock_routing {
                 })
                 .then(move |res| {
                     unwrap!(res);
-                    client5.list_mdata_user_permissions_new(address, user0)
+                    client5.list_mdata_user_permissions(address, user0)
                 })
                 .then(move |res| {
                     match res {

--- a/safe_core/src/connection_manager.rs
+++ b/safe_core/src/connection_manager.rs
@@ -9,7 +9,7 @@
 mod connection_group;
 
 use crate::{
-    client::NewFullId,
+    client::SafeKey,
     event::{NetworkEvent, NetworkTx},
     CoreError, CoreFuture,
 };
@@ -85,7 +85,7 @@ impl ConnectionManager {
     }
 
     /// Connect to Client Handlers that manage the provided ID.
-    pub fn bootstrap(&mut self, full_id: NewFullId) -> Box<CoreFuture<()>> {
+    pub fn bootstrap(&mut self, full_id: SafeKey) -> Box<CoreFuture<()>> {
         trace!("Trying to bootstrap with group {:?}", full_id.public_id());
 
         let elders = Default::default();

--- a/safe_core/src/connection_manager/connection_group.rs
+++ b/safe_core/src/connection_manager/connection_group.rs
@@ -9,7 +9,7 @@
 // TODO - remove this.
 #![allow(dead_code)]
 
-use crate::{client::NewFullId, utils, CoreError, CoreFuture};
+use crate::{client::SafeKey, utils, CoreError, CoreFuture};
 use bincode::{deserialize, serialize};
 use bytes::Bytes;
 use futures::{
@@ -60,7 +60,7 @@ impl Elder {
 /// Encapsulates multiple QUIC connections with a group of Client Handlers.
 /// Accumulates responses. During Phase 1 connects only to a single vault.
 pub(super) struct ConnectionGroup {
-    full_id: NewFullId,
+    full_id: SafeKey,
     elders: HashMap<SocketAddr, Elder>,
     hooks: HashMap<MessageId, Sender<Response>>, // to be replaced with Accumulator for multiple vaults.
     quic_p2p: Arc<Mutex<QuicP2p>>,
@@ -71,7 +71,7 @@ pub(super) struct ConnectionGroup {
 
 impl ConnectionGroup {
     pub fn new(
-        full_id: NewFullId,
+        full_id: SafeKey,
         mut elders: HashSet<NodeInfo>,
         quic_p2p: Arc<Mutex<QuicP2p>>,
         connection_hook: Sender<Result<(), CoreError>>,

--- a/safe_core/src/errors.rs
+++ b/safe_core/src/errors.rs
@@ -48,7 +48,7 @@ pub enum CoreError {
     /// Routing Client Error.
     RoutingClientError(ClientError),
     /// Routing Client Error.
-    NewRoutingClientError(SndError),
+    DataError(SndError),
     /// Unable to pack into or operate with size of Salt.
     UnsupportedSaltSizeForPwHash,
     /// Unable to complete computation for password hashing - usually because OS
@@ -114,7 +114,7 @@ impl From<ClientError> for CoreError {
 
 impl From<SndError> for CoreError {
     fn from(error: SndError) -> Self {
-        Self::NewRoutingClientError(error)
+        Self::DataError(error)
     }
 }
 
@@ -193,9 +193,7 @@ impl Debug for CoreError {
             Self::RoutingClientError(ref error) => {
                 write!(formatter, "CoreError::RoutingClientError -> {:?}", error)
             }
-            Self::NewRoutingClientError(ref error) => {
-                write!(formatter, "CoreError::NewRoutingClientError -> {:?}", error)
-            }
+            Self::DataError(ref error) => write!(formatter, "CoreError::DataError -> {:?}", error),
             Self::UnsupportedSaltSizeForPwHash => {
                 write!(formatter, "CoreError::UnsupportedSaltSizeForPwHash")
             }
@@ -252,9 +250,7 @@ impl Display for CoreError {
             Self::RoutingClientError(ref error) => {
                 write!(formatter, "Routing client error -> {}", error)
             }
-            Self::NewRoutingClientError(ref error) => {
-                write!(formatter, "New Routing client error -> {}", error)
-            }
+            Self::DataError(ref error) => write!(formatter, "Data error -> {}", error),
             Self::UnsupportedSaltSizeForPwHash => write!(
                 formatter,
                 "Unable to pack into or operate with size of Salt"
@@ -295,7 +291,7 @@ impl StdError for CoreError {
             Self::RoutingError(_) => "Routing internal error",
             // TODO - use `error.description()` once `InterfaceError` implements `std::error::Error`
             Self::RoutingClientError(ref error) => error.description(),
-            Self::NewRoutingClientError(ref error) => error.description(),
+            Self::DataError(ref error) => error.description(),
             Self::RoutingInterfaceError(_) => "Routing interface error",
             Self::UnsupportedSaltSizeForPwHash => "Unsupported size of salt",
             Self::UnsuccessfulPwHash => "Failed while password hashing",

--- a/safe_core/src/nfs/dir.rs
+++ b/safe_core/src/nfs/dir.rs
@@ -33,7 +33,7 @@ pub fn create_dir(
             trace!("Error: {:?}", err);
             match err {
                 // This dir has been already created
-                CoreError::NewRoutingClientError(SndError::DataExists) => Ok(()),
+                CoreError::DataError(SndError::DataExists) => Ok(()),
                 e => Err(e),
             }
         })

--- a/safe_core/src/nfs/file_helper.rs
+++ b/safe_core/src/nfs/file_helper.rs
@@ -227,7 +227,7 @@ pub fn write<C: Client>(
 // TODO:  consider performing such conversion directly in the mentioned `impl From`.
 fn convert_error(err: CoreError) -> NfsError {
     match err {
-        CoreError::NewRoutingClientError(SndError::NoSuchEntry) => NfsError::FileNotFound,
+        CoreError::DataError(SndError::NoSuchEntry) => NfsError::FileNotFound,
         _ => NfsError::from(err),
     }
 }

--- a/safe_core/src/nfs/tests.rs
+++ b/safe_core/src/nfs/tests.rs
@@ -238,9 +238,7 @@ fn files_stored_in_unpublished_idata() {
         file_helper::fetch(client.clone(), dir.clone(), "").then(|res| {
             match res {
                 Ok(_) => panic!("Unexpected success"),
-                Err(NfsError::CoreError(CoreError::NewRoutingClientError(
-                    SndError::AccessDenied,
-                ))) => (),
+                Err(NfsError::CoreError(CoreError::DataError(SndError::AccessDenied))) => (),
                 Err(err) => panic!("Unexpected error: {:?}", err),
             }
             Ok::<_, CoreError>(())


### PR DESCRIPTION
- `NewRoutingClientError` renamed to `DataError`
- `NewFullId` renamed to `SafeKey`
- Removes `_new` from the new client APIs
- Removes older APIs which used legacy data types